### PR TITLE
fix(ci): allow pushing docker images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - 'go'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4


### PR DESCRIPTION
The ability for the on-merge workflow runs to push was broken by organization-level policies reducing the permissions available to the default GITHUB_TOKEN.