### PR TITLE
feat: use stable 'alpine' regctl image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY ./ ./
 
 RUN CGO_ENABLED=0 go build -o /go/bin/composevalidate -trimpath -ldflags="-s -w" .
 
-FROM ghcr.io/regclient/regctl:edge-alpine@sha256:37e50b41c26c56aa142acad4a63051d280592f514ba9a75d7232c5b133edba49
+FROM ghcr.io/regclient/regctl:alpine
 
 COPY --from=build /go/bin/composevalidate /usr/local/bin/
 


### PR DESCRIPTION
We do not need to track the latest builds of regsync in the 'edge:alpine' tag, so base on 'alpine' instead in order to reduce the frequency of updates.