### PR TITLE
chore: migrate Renovate base preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     ":automergeAll",
     ":gitSignOff",
     ":semanticCommits",


### PR DESCRIPTION
## Summary

- Migrate Renovate's deprecated `config:base` preset to `config:recommended`.
- Leave the rest of the Renovate rules unchanged.

## Context

Renovate's Dependency Dashboard (#5) currently shows **Config Migration Needed**. This is a small reversible config-only cleanup so Renovate can stop flagging that migration item while keeping the existing automerge, semantic commit, Docker digest pinning, regex manager, and Go post-update behavior intact.

## Validation

- `python3 -m json.tool renovate.json`

No registry, credential, package-version, or workflow behavior changes included.
